### PR TITLE
Add README with viewing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Khan Majid CV
+
+This repository contains the curriculum vitae for Khan Majid in PDF format.
+
+## Viewing via GitHub
+
+You can view the PDF directly in your browser by opening the [KhanMajid_MDPhD_CV_051225.pdf](./KhanMajid_MDPhD_CV_051225.pdf) file on GitHub. GitHub provides a built-in PDF viewer so the document will render automatically.
+
+## Viewing via GitHub Pages
+
+If this repository has GitHub Pages enabled, you can view a hosted HTML version of the CV. Visit `https://<USERNAME>.github.io/<REPOSITORY>/` (replace `<USERNAME>` and `<REPOSITORY>` with the GitHub account name and repository name). This page should display the same PDF.
+


### PR DESCRIPTION
## Summary
- add README that explains how to view the CV through GitHub's PDF viewer
- provide instructions for checking a GitHub Pages hosted HTML page

## Testing
- `git status --short`